### PR TITLE
Add overall timeout of 10 seconds

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aws/aws-signer-notation-plugin/internal/logger"
 	"github.com/aws/aws-signer-notation-plugin/plugin"
@@ -28,7 +29,9 @@ const debugFlag = "AWS_SIGNER_NOTATION_PLUGIN_DEBUG"
 
 func main() {
 	awsPlugin := plugin.NewAWSSignerForCLI()
-	ctx := context.Background()
+	// plugin should finish execution in 10 seconds
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	var pluginCli *cli.CLI
 	var err error


### PR DESCRIPTION
*Issue #, if available:*
Currently there is no timeout set when plugin is executed as binary.

*Description of changes:*
This PR implements a 10-second overall execution time limit for the plugin to execute signing and verification.

#### TODO: Have better timeout for GenerateEnvelope and Verify operations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
