### PR TITLE
Move go build version to 1.23.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ "1.23.1" ]
+        go-version: [ "1.23.12" ]
       fail-fast: true
     steps:
       - name: Check out code


### PR DESCRIPTION
*Description of changes:*
Hi there,

After the recent dependency update, this package still has CVE's against it from the golang standard library.

This should hopefully fix that by updating to the latest 1.23.x version for the build.

If possible I'd update to 1.24.x/1.25.x but I'll leave that up to you because I want to avoid breaking the build if I can :).

Cheers!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.