### PR TITLE
feat: Support verification of alias-signed artifacts

### DIFF
--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -38,6 +38,7 @@ const (
 
 	attrSigningProfileVersion = "com.amazonaws.signer.signingProfileVersion"
 	attrSigningJob            = "com.amazonaws.signer.signingJob"
+	attrSigningProfileAlias   = "com.amazonaws.signer.signingProfileAlias"
 	signingSchemeAuthority    = "notary.x509.signingAuthority"
 
 	errMsgCertificateParse = "unable to parse certificates in certificate chain."
@@ -100,6 +101,10 @@ func (v *Verifier) Verify(ctx context.Context, request *plugin.VerifySignatureRe
 	// return both of them as processed even if the revocation call was skipped
 	response.ProcessedAttributes = slices.AppendIfNotPresent(response.ProcessedAttributes, attrSigningProfileVersion)
 	response.ProcessedAttributes = slices.AppendIfNotPresent(response.ProcessedAttributes, attrSigningJob)
+	// Mark signingProfileAlias processed when present, else Notation fails closed on it.
+	if _, ok := request.Signature.CriticalAttributes.ExtendedAttributes[attrSigningProfileAlias]; ok {
+		response.ProcessedAttributes = slices.AppendIfNotPresent(response.ProcessedAttributes, attrSigningProfileAlias)
+	}
 	return &response, nil
 }
 
@@ -136,12 +141,8 @@ func validateTrustedIdentity(request *plugin.VerifySignatureRequest, response *p
 		return err
 	}
 
-	var trustedArns []string
-	for _, identity := range request.TrustPolicy.TrustedIdentities {
-		if _, ok := isSigningProfileArn(identity); ok {
-			trustedArns = append(trustedArns, identity)
-		}
-	}
+	// Alias ARN of the signing profile; empty for non-aliased profiles.
+	signatureAlias, _ := getValueAsString(request.Signature.CriticalAttributes.ExtendedAttributes, attrSigningProfileAlias)
 
 	result := &plugin.VerificationResult{
 		Success: false,
@@ -150,9 +151,19 @@ func validateTrustedIdentity(request *plugin.VerifySignatureRequest, response *p
 
 	var profileMatch bool
 	for _, identity := range request.TrustPolicy.TrustedIdentities {
-		if arn, ok := isSigningProfileArn(identity); ok {
+		// Match a trusted alias ARN against the signature's alias.
+		if isAliasArn(identity) {
+			if signatureAlias != "" && strings.EqualFold(signatureAlias, identity) {
+				profileMatch = true
+			}
+		} else if arn, ok := isSigningProfileArn(identity); ok {
 			s := strings.Split(arn.Resource, "/")
-			if len(s) == 3 { // if profile arn
+			if strings.HasPrefix(arn.Resource, "/aliased-signing-profiles/") {
+				// Aliased resource ARN as trust anchor (matches signingProfileVersion for ALIAS_ONLY).
+				if strings.EqualFold(signatureIdentity, identity) {
+					profileMatch = true
+				}
+			} else if len(s) == 3 { // if profile arn
 				lastIndex := strings.LastIndex(signatureIdentity, "/")
 				if lastIndex != -1 && strings.EqualFold(signatureIdentity[:lastIndex], identity) {
 					profileMatch = true
@@ -162,11 +173,11 @@ func validateTrustedIdentity(request *plugin.VerifySignatureRequest, response *p
 					profileMatch = true
 				}
 			}
-			if profileMatch {
-				result.Success = true
-				result.Reason = fmt.Sprintf(reasonTrustedIdentitySuccessFmt, identity)
-				break
-			}
+		}
+		if profileMatch {
+			result.Success = true
+			result.Reason = fmt.Sprintf(reasonTrustedIdentitySuccessFmt, identity)
+			break
 		}
 	}
 
@@ -176,10 +187,20 @@ func validateTrustedIdentity(request *plugin.VerifySignatureRequest, response *p
 
 func isSigningProfileArn(s string) (arn.ARN, bool) {
 	if a, err := arn.Parse(s); err == nil {
-		return a, a.Service == "signer" && strings.HasPrefix(a.Resource, "/signing-profiles/")
+		return a, a.Service == "signer" &&
+			(strings.HasPrefix(a.Resource, "/signing-profiles/") ||
+				strings.HasPrefix(a.Resource, "/aliased-signing-profiles/"))
 	}
 
 	return arn.ARN{}, false
+}
+
+func isAliasArn(s string) bool {
+	if a, err := arn.Parse(s); err == nil {
+		return a.Service == "signer" && strings.HasPrefix(a.Resource, "/aliases/")
+	}
+
+	return false
 }
 
 func getValueAsString(m map[string]interface{}, k string) (string, error) {

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -33,6 +33,8 @@ import (
 const (
 	testProfileArn        = "arn:aws:signer:us-west-2:000000000000:/signing-profiles/NotaryPluginIntegProfile"
 	testProfileVersionArn = testProfileArn + "/OF8IVUsPJq"
+	testAliasedProfileArn = "arn:aws:signer:us-west-2::/aliased-signing-profiles/db4a39f3-f858-4b92-8623-8b4c41649972"
+	testAliasArn          = "arn:aws:signer:::/aliases/com.amazonaws.aliastest"
 	testJobArn            = "arn:aws:signer:us-west-2:000000000000:/signing-jobs/97af3947-e7b2-4533-8d9d-6741156f0b79"
 	testCertificate1      = `-----BEGIN CERTIFICATE-----
 MIIDQDCCAiigAwIBAgIRAMH0R+Owv6zXRzRJgjkWUPEwDQYJKoZIhvcNAQELBQAw
@@ -90,6 +92,92 @@ func TestVerify(t *testing.T) {
 	actualResponse, err := New(mockSignerClient).Verify(context.TODO(), request)
 	expectedResponse := getVerifySigResponse(true, testTISuccessReason, true, reasonNotRevoked)
 	validateResponse(t, expectedResponse, *actualResponse, err)
+}
+
+func TestVerify_SigningProfileAliasProcessed(t *testing.T) {
+	// A signature carrying signingProfileAlias must report it as a processed attribute.
+	mockSignerClient, mockCtrl := getMockClient(nil, &signer.GetRevocationStatusOutput{}, nil, t)
+	defer mockCtrl.Finish()
+
+	aliasArn := "arn:aws:signer:us-west-2::/aliases/com.amazonaws.aliastest"
+	request := mockVerifySigRequest()
+	request.TrustPolicy.TrustedIdentities = []string{testProfileVersionArn}
+	request.Signature.CriticalAttributes.ExtendedAttributes[attrSigningProfileAlias] = aliasArn
+
+	actualResponse, err := New(mockSignerClient).Verify(context.TODO(), request)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	assert.Contains(t, actualResponse.ProcessedAttributes, attrSigningProfileAlias,
+		"signingProfileAlias must be reported as a processed attribute when present")
+}
+
+func TestVerify_AliasedTrustedIdentity(t *testing.T) {
+	// Trusting the aliased resource ARN should match a signature signed under it.
+	mockSignerClient, mockCtrl := getMockClient(nil, &signer.GetRevocationStatusOutput{}, nil, t)
+	defer mockCtrl.Finish()
+
+	request := mockVerifySigRequest()
+	request.Signature.CriticalAttributes.ExtendedAttributes[attrSigningProfileVersion] = testAliasedProfileArn
+	request.TrustPolicy.TrustedIdentities = []string{testAliasedProfileArn}
+
+	actualResponse, err := New(mockSignerClient).Verify(context.TODO(), request)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	ti := actualResponse.VerificationResults[plugin.CapabilityTrustedIdentityVerifier]
+	assert.True(t, ti.Success, "aliased ARN in trustedIdentities should match the aliased signingProfileVersion")
+}
+
+func TestVerify_AliasedTrustedIdentity_Mismatch(t *testing.T) {
+	// Trusting a different aliased ARN than the signature's must not match.
+	mockSignerClient, mockCtrl := getMockClient(nil, &signer.GetRevocationStatusOutput{}, nil, t)
+	defer mockCtrl.Finish()
+
+	request := mockVerifySigRequest()
+	request.Signature.CriticalAttributes.ExtendedAttributes[attrSigningProfileVersion] = testAliasedProfileArn
+	request.TrustPolicy.TrustedIdentities = []string{"arn:aws:signer:us-west-2::/aliased-signing-profiles/00000000-0000-0000-0000-000000000000"}
+
+	actualResponse, err := New(mockSignerClient).Verify(context.TODO(), request)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	ti := actualResponse.VerificationResults[plugin.CapabilityTrustedIdentityVerifier]
+	assert.False(t, ti.Success, "a non-matching aliased ARN must not be trusted")
+}
+
+func TestVerify_AliasTrustedIdentity(t *testing.T) {
+	// Trusting the alias ARN should match the signature's signingProfileAlias.
+	mockSignerClient, mockCtrl := getMockClient(nil, &signer.GetRevocationStatusOutput{}, nil, t)
+	defer mockCtrl.Finish()
+
+	request := mockVerifySigRequest()
+	request.Signature.CriticalAttributes.ExtendedAttributes[attrSigningProfileAlias] = testAliasArn
+	request.TrustPolicy.TrustedIdentities = []string{testAliasArn}
+
+	actualResponse, err := New(mockSignerClient).Verify(context.TODO(), request)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	ti := actualResponse.VerificationResults[plugin.CapabilityTrustedIdentityVerifier]
+	assert.True(t, ti.Success, "alias ARN in trustedIdentities should match the signature's signingProfileAlias")
+}
+
+func TestVerify_AliasTrustedIdentity_Mismatch(t *testing.T) {
+	// Trusting a different alias than the signature carries must not match.
+	mockSignerClient, mockCtrl := getMockClient(nil, &signer.GetRevocationStatusOutput{}, nil, t)
+	defer mockCtrl.Finish()
+
+	request := mockVerifySigRequest()
+	request.Signature.CriticalAttributes.ExtendedAttributes[attrSigningProfileAlias] = testAliasArn
+	request.TrustPolicy.TrustedIdentities = []string{"arn:aws:signer:::/aliases/com.amazonaws.someotheralias"}
+
+	actualResponse, err := New(mockSignerClient).Verify(context.TODO(), request)
+	if err != nil {
+		t.Fatalf("Unexpected error: %+v", err)
+	}
+	ti := actualResponse.VerificationResults[plugin.CapabilityTrustedIdentityVerifier]
+	assert.False(t, ti.Success, "a non-matching alias must not be trusted")
 }
 
 func TestVerify_ValidTrustedIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary

Enable `notation verify` for AWS Signer alias-signed artifacts. Signatures produced by alias-associated profiles carry a `com.amazonaws.signer.signingProfileAlias` attribute, and for `ALIAS_ONLY` profiles the `signingProfileVersion` is an aliased-resource ARN (`.../aliased-signing-profiles/{uuid}`). Before this change the plugin could not verify these signatures at all.

## Changes

- **Mark `signingProfileAlias` as processed** when the signature carries it, so Notation does not fail closed on an unprocessed critical attribute.
- **Accept `/aliased-signing-profiles/` ARNs** (not just `/signing-profiles/`) as valid signing-profile identities for trusted-identity matching.
- **Add alias-based trust:** when a trusted identity is an alias ARN (`/aliases/{alias}`), match it against the signature's `signingProfileAlias` attribute — so verifiers can trust the stable alias rather than an opaque profile ARN.

## Why

Without this change, verifying any alias-signed artifact fails with one of:
- `extended critical attribute "com.amazonaws.signer.signingProfileAlias" was not processed by the verification plugin`
- `Signature publisher doesn't match any trusted identities`

## Testing

- ✅ Unit tests pass (verifier package at 99.2% coverage). New tests: `TestVerify_SigningProfileAliasProcessed`, `TestVerify_AliasTrustedIdentity` / `_Mismatch`, `TestVerify_AliasedTrustedIdentity` / `_Mismatch`.
- ✅ Plugin builds successfully (`make build`).
- ✅ E2E tests pass — built this branch's binary, ran the Brazil `bb e2e-tests` suite; all existing e2e tests pass.
- ✅ Verified end to end on beta: signed an `ALIAS_ONLY` container image, and `notation verify` succeeded with a trust policy trusting only the alias ARN, while a wrong alias failed.

---

**Issue #, if available:** N/A

**Description of changes:** See Summary above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
